### PR TITLE
Try to parse "string-ified" params values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Try to parse "string-ified" params values (sirykd)
+
 ## 0.1.1 
 - Fix MLFlow active runs' query (mihran113)
 - Add `PyPI` long description (mihran113)

--- a/aimlflow/utils.py
+++ b/aimlflow/utils.py
@@ -1,9 +1,11 @@
 import click
+import collections
 import mlflow
 import json
 import time
 import os.path
 
+from ast import literal_eval
 from tempfile import TemporaryDirectory
 from tqdm import tqdm
 
@@ -108,7 +110,8 @@ def collect_run_params(aim_run, mlflow_run):
     aim_run.description = mlflow_run.data.tags.get("mlflow.note.content")
 
     # Collect params & tags
-    aim_run['params'] = mlflow_run.data.params
+    # MLflow provides "string-ified" params values and we try to revert that
+    aim_run['params'] = _map_nested_dicts(_try_parse_str, mlflow_run.data.params)
     aim_run['tags'] = {
         k: v for k, v in mlflow_run.data.tags.items() if not k.startswith('mlflow')
     }
@@ -226,3 +229,18 @@ def _wait_forever(watcher):
             time.sleep(24 * 60 * 60)  # sleep for a day
     except KeyboardInterrupt:
         watcher.stop()
+
+
+def _map_nested_dicts(fun, tree):
+    if isinstance(tree, collections.Mapping):
+        return {k: _map_nested_dicts(fun, subtree) for k, subtree in tree.items()}
+    else:
+        return fun(tree)
+
+
+def _try_parse_str(s):
+    assert isinstance(s, str), f'Expected a string, got {s} of type {type(s)}'
+    try:
+        return literal_eval(s.strip())
+    except:  # noqa: E722
+        return s


### PR DESCRIPTION
Resolves #6

This PR addresses an issue with MLflow providing parameter values as strings, which makes Aim see and treat inherently numeric or compound (list, etc.) parameter values as string values and thus negatively affects user experience.

| Before | After |
| -------| ----- |
| <img src="https://user-images.githubusercontent.com/23129117/215550956-15c9b979-9a30-406b-81a7-fb096c24a171.png"> | ![image](https://user-images.githubusercontent.com/23129117/216184606-348a4b39-e0ac-46d4-ab09-432db15c8502.png) |

The code is based on a few assumptions:
- _MLflow always provides "string-ified" param values_
   The docs of `RunData` don't mention the type of values in `data.params`: 
    `Dictionary of param key (string) -> param value for the current run`.
   Still, both `Param` and `log_param()` explicitly mention the "string-ification" of `value` (see comment [#6](https://github.com/aimhubio/aimlflow/issues/6#issuecomment-1411071574)).
- _Users always prefer parsing over dealing with strings_

Both assumptions could be relaxed (check type instead of assertion, control parsing via cli) depending on both your opinion and future feedback/updates.