### PR TITLE
Fix deprecated (as of Python 3.10) `Mapping` reference

### DIFF
--- a/aimlflow/utils.py
+++ b/aimlflow/utils.py
@@ -245,7 +245,7 @@ def _wait_forever(watcher):
 
 
 def _map_nested_dicts(fun, tree):
-    if isinstance(tree, collections.Mapping):
+    if isinstance(tree, collections.abc.Mapping):
         return {k: _map_nested_dicts(fun, subtree) for k, subtree in tree.items()}
     else:
         return fun(tree)


### PR DESCRIPTION
Proposed fix for issue #16. I did some [very] rudimentary backwards compatibility testing of `collections.abc.Mapping` for Python 3.7-3.9, which from `setup.py`  appears to be the lowest Python version supported.